### PR TITLE
Use new ref syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-progress",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "progress ui component for react",
   "keywords": [
     "react",

--- a/src/Line.jsx
+++ b/src/Line.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
           stroke={strokeColor}
           strokeWidth={strokeWidth}
           fillOpacity="0"
-          ref="path"
+          ref={(path) => { this.path = path; }}
           style={pathStyle}
         />
       </svg>

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -24,9 +24,9 @@ export default {
   },
   componentDidUpdate() {
     const now = Date.now();
-    this.refs.path.style.transitionDuration = '0.3s, 0.3s';
+    this.path.style.transitionDuration = '0.3s, 0.3s';
     if (this.prevTimeStamp && now - this.prevTimeStamp < 100) {
-      this.refs.path.style.transitionDuration = '0s, 0s';
+      this.path.style.transitionDuration = '0s, 0s';
     }
     this.prevTimeStamp = Date.now();
   },


### PR DESCRIPTION
According to https://facebook.github.io/react/docs/refs-and-the-dom.html
```
Using the ref callback just to set a property on the class is a common
pattern for accessing DOM elements.
If you are currently using this.refs.myRefName to access refs,
we recommend using this pattern instead.
```