### PR TITLE
Fix when circle percent == 0, stroke width it is still visible

### DIFF
--- a/src/Circle.js
+++ b/src/Circle.js
@@ -54,6 +54,7 @@ class Circle extends Component {
       trailColor, strokeLinecap, style, className, ...restProps,
     } = this.props;
     const { pathString, trailPathStyle, strokePathStyle } = this.getPathStyles();
+    const showCirclePath = restProps.percent > 0;
     delete restProps.percent;
     delete restProps.gapDegree;
     delete restProps.gapPosition;
@@ -72,6 +73,7 @@ class Circle extends Component {
           fillOpacity="0"
           style={trailPathStyle}
         />
+      {showCirclePath &&
         <path
           className={`${prefixCls}-circle-path`}
           d={pathString}
@@ -81,7 +83,7 @@ class Circle extends Component {
           fillOpacity="0"
           ref={(path) => { this.path = path; }}
           style={strokePathStyle}
-        />
+        />}
       </svg>
     );
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,7 +5,7 @@ const Line = require('../').Line;
 const Circle = require('../').Circle;
 
 describe('line progress', () => {
-  it('work', () => {
+  it('works', () => {
     const div = document.createElement(div);
     document.body.appendChild(div);
     const line = ReactDOM.render(<Line percent="30" strokeWidth="1" />, div);
@@ -15,7 +15,7 @@ describe('line progress', () => {
 });
 
 describe('circle progress', () => {
-  it('work', () => {
+  it('works', () => {
     const div = document.createElement(div);
     document.body.appendChild(div);
     const circle = ReactDOM.render(<Circle percent="30" strokeWidth="1" />, div);
@@ -60,6 +60,15 @@ describe('circle progress', () => {
       <Circle percent="30" strokeWidth="1" gapDegree={70} gapPosition="right" />
     , div);
     expect(circle.props.percent).to.be('30');
+    ReactDOM.unmountComponentAtNode(div);
+  });
+
+  it('doesn\'t render the circle path if at 0 percent', () => {
+    const div = document.createElement(div);
+    document.body.appendChild(div);
+    ReactDOM.render(<Circle percent="0" strokeWidth="1" />, div);
+    const circlePathsLength = document.getElementsByClassName('rc-progress-circle-path').length;
+    expect(circlePathsLength).to.be(0);
     ReactDOM.unmountComponentAtNode(div);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/react-component/progress/issues/15 (when circle percent 0 - stroke width it is still visible.)

Could also be achieved by changing the line butt ending.