### PR TITLE
Progress type circle animation when percentage changes from 0

### DIFF
--- a/src/Circle.js
+++ b/src/Circle.js
@@ -107,7 +107,8 @@ class Circle extends Component {
           d={pathString}
           stroke={stroke}
           strokeLinecap={strokeLinecap}
-          strokeWidth={ptg === 0 ? 0 : strokeWidth}
+          strokeWidth={strokeWidth}
+          opacity={ptg === 0 ? 0 : 1}
           fillOpacity="0"
           style={pathStyle}
           ref={path => {


### PR DESCRIPTION
Changes strokeWidth to always equal strokeWidth.
Adds opacity set to 0 on 0 progress (ptg), otherwise 1.

Due to the CSS transition and element width race-condition there is a need to keep the width greater than 0.