### PR TITLE
fix: Incorrect useRef usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default () => (
     </tr>
     <tr>
       <td>percent</td>
-      <td>Number</td>
+      <td>Number | Number[]</td>
       <td>0</td>
       <td>the percent of the progress</td>
     </tr>

--- a/docs/examples/gap.tsx
+++ b/docs/examples/gap.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Circle, ProgressProps } from 'rc-progress';
 
-const colorMap = ['#3FC7FA', '#85D262', '#FE8C6A'];
+const colorMap = ['#3FC7FA', '#85D262', '#FE8C6A', '#FF5959', '#BC3FFA'];
 
 function getColor(index) {
   return colorMap[(index + colorMap.length) % colorMap.length];
@@ -13,8 +13,10 @@ class Example extends React.Component<ProgressProps, any> {
     this.state = {
       percent: 30,
       colorIndex: 0,
+      subPathsCount: 3,
     };
     this.changeState = this.changeState.bind(this);
+    this.changeCount = this.changeCount.bind(this);
   }
 
   changeState() {
@@ -26,18 +28,37 @@ class Example extends React.Component<ProgressProps, any> {
     });
   }
 
+  changeCount() {
+    this.setState({
+      ...this.state,
+      subPathsCount: (this.state.subPathsCount % 6) + 1,
+    });
+  }
+
   render() {
     const circleContainerStyle = {
       width: '200px',
       height: '200px',
     };
-    const { percent, colorIndex } = this.state;
+    const { percent, colorIndex, subPathsCount } = this.state;
     const color = getColor(colorIndex);
+
+    const multiPercentage = new Array(subPathsCount).fill(
+      percent / subPathsCount,
+      0,
+      subPathsCount,
+    );
+    const multiPercentageStrokeColors = multiPercentage.map((v, index) => getColor(index));
+
     return (
       <div>
         <p>
           <button type="button" onClick={this.changeState}>
             Change State [{percent}]
+          </button>
+
+          <button type="button" onClick={this.changeCount}>
+            Change Count [{subPathsCount}]
           </button>
         </p>
         <div style={circleContainerStyle}>
@@ -52,13 +73,13 @@ class Example extends React.Component<ProgressProps, any> {
         </div>
         <div style={circleContainerStyle}>
           <Circle
-            percent={[percent / 3, percent / 3, percent / 3]}
+            percent={multiPercentage}
             gapDegree={70}
             gapPosition="bottom"
             strokeWidth={6}
             trailWidth={6}
             strokeLinecap="round"
-            strokeColor={[color, getColor(colorIndex + 1), getColor(colorIndex + 2)]}
+            strokeColor={multiPercentageStrokeColors}
           />
         </div>
 

--- a/src/Circle.tsx
+++ b/src/Circle.tsx
@@ -96,7 +96,7 @@ const Circle: React.FC<ProgressProps> = ({
     (color) => Object.prototype.toString.call(color) === '[object Object]',
   );
 
-  const [paths] = useTransitionDuration(percentList);
+  const paths = useTransitionDuration();
 
   const getStokeList = () => {
     let stackPtg = 0;
@@ -119,7 +119,14 @@ const Circle: React.FC<ProgressProps> = ({
           opacity={ptg === 0 ? 0 : 1}
           fillOpacity="0"
           style={pathStyles.pathStyle}
-          ref={paths[index]}
+          ref={(elem) => {
+            // https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
+            // React will call the ref callback with the DOM element when the component mounts,
+            // and call it with `null` when it unmounts.
+            // Refs are guaranteed to be up-to-date before componentDidMount or componentDidUpdate fires.
+
+            paths[index] = elem;
+          }}
         />
       );
     });

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { useTransitionDuration, defaultProps } from './common';
-import { ProgressProps } from './interface';
+import type { ProgressProps } from './interface';
 
 const Line: React.FC<ProgressProps> = ({
   className,
@@ -21,7 +21,7 @@ const Line: React.FC<ProgressProps> = ({
   const percentList = Array.isArray(percent) ? percent : [percent];
   const strokeColorList = Array.isArray(strokeColor) ? strokeColor : [strokeColor];
 
-  const [paths] = useTransitionDuration(percentList);
+  const paths = useTransitionDuration();
 
   const center = strokeWidth / 2;
   const right = 100 - strokeWidth / 2;
@@ -76,7 +76,14 @@ const Line: React.FC<ProgressProps> = ({
             stroke={color as string}
             strokeWidth={strokeWidth}
             fillOpacity="0"
-            ref={paths[index]}
+            ref={(elem) => {
+              // https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
+              // React will call the ref callback with the DOM element when the component mounts,
+              // and call it with `null` when it unmounts.
+              // Refs are guaranteed to be up-to-date before componentDidMount or componentDidUpdate fires.
+
+              paths[index] = elem;
+            }}
             style={pathStyle}
           />
         );

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from 'react';
-import { ProgressProps } from './interface';
+import type { ProgressProps } from './interface';
 
 export const defaultProps: Partial<ProgressProps> = {
   className: '',
@@ -13,19 +13,19 @@ export const defaultProps: Partial<ProgressProps> = {
   trailWidth: 1,
 };
 
-export const useTransitionDuration = (percentList: number[]) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const paths = percentList.map(() => useRef());
+export const useTransitionDuration = (): SVGPathElement[] => {
+  const pathsRef = useRef<SVGPathElement[]>([]);
   const prevTimeStamp = useRef(null);
+
   useEffect(() => {
     const now = Date.now();
     let updated = false;
 
-    Object.keys(paths).forEach(key => {
-      const path = paths[key].current;
+    pathsRef.current.forEach((path) => {
       if (!path) {
         return;
       }
+
       updated = true;
       const pathStyle = path.style;
       pathStyle.transitionDuration = '.3s, .3s, .3s, .06s';
@@ -40,5 +40,5 @@ export const useTransitionDuration = (percentList: number[]) => {
     }
   });
 
-  return [paths];
+  return pathsRef.current;
 };

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -156,4 +156,34 @@ describe('Progress', () => {
       );
     });
   });
+
+  it('should support percentage array changes', () => {
+    class Demo extends React.Component {
+      state = {
+        subPathsCount: 2,
+      };
+
+      render() {
+        const { subPathsCount } = this.state;
+        const percent = 80;
+        const multiPercentage = new Array(subPathsCount).fill(
+          percent / subPathsCount,
+          0,
+          subPathsCount,
+        );
+
+        return (
+          <>
+            <Circle percent={multiPercentage} strokeWidth="1" />
+            <Line percent={multiPercentage} strokeWidth="1" />
+          </>
+        );
+      }
+    }
+    const circle = mount(<Demo />);
+    expect(circle.find(Circle).props().percent).toEqual([40, 40]);
+    circle.setState({ subPathsCount: 4 });
+    expect(circle.find(Circle).props().percent).toEqual([20, 20, 20, 20]);
+    circle.unmount();
+  });
 });


### PR DESCRIPTION
Fixes this issue https://github.com/react-component/progress/issues/83

If an array is passed as `percent` prop and its length is changed dynamically, 'Rendered more hooks than during the previous render' react error appears.

The issue was in incorrect `useRef` usage silenced by `// eslint-disable-next-line react-hooks/rules-of-hooks`

I believe now it works correctly without any change of actual logic. 

I've added 1 test and altered the 'gap' example a bit to check if it is working correctly. 

