### PR TITLE
Fix for - SVGs for progress bar are not indicated to be decorative

### DIFF
--- a/src/Circle.tsx
+++ b/src/Circle.tsx
@@ -202,6 +202,7 @@ const Circle: React.FC<ProgressProps> = ({
       viewBox={`0 0 ${VIEW_BOX_SIZE} ${VIEW_BOX_SIZE}`}
       style={style}
       id={id}
+      role="presentation"
       {...restProps}
     >
       {gradient && (

--- a/tests/__snapshots__/index.spec.js.snap
+++ b/tests/__snapshots__/index.spec.js.snap
@@ -86,6 +86,7 @@ exports[`Progress Circle should gradient works and circles have different gradie
 <div>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <defs>
@@ -130,6 +131,7 @@ exports[`Progress Circle should gradient works and circles have different gradie
   </svg>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <defs>
@@ -179,6 +181,7 @@ exports[`Progress Circle should show right gapPosition 1`] = `
 <div>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <circle
@@ -204,6 +207,7 @@ exports[`Progress Circle should show right gapPosition 1`] = `
   </svg>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <circle
@@ -229,6 +233,7 @@ exports[`Progress Circle should show right gapPosition 1`] = `
   </svg>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <circle
@@ -254,6 +259,7 @@ exports[`Progress Circle should show right gapPosition 1`] = `
   </svg>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <circle
@@ -279,6 +285,7 @@ exports[`Progress Circle should show right gapPosition 1`] = `
   </svg>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <circle
@@ -304,6 +311,7 @@ exports[`Progress Circle should show right gapPosition 1`] = `
   </svg>
   <svg
     class="rc-progress-circle"
+    role="presentation"
     viewBox="0 0 100 100"
   >
     <circle


### PR DESCRIPTION
Ref: UIEN-1660
Progress bars are labelled with a value representing the progress that screen readers will announce. The progress bar SVGs, however, are currently not marked as decorative in which case screen readers can/will make announcements with redundancy.