### PR TITLE
fix: Circle should work correctly in safari with zoom in/out

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -43,3 +43,8 @@ export const useTransitionDuration = (): SVGPathElement[] => {
 
   return pathsRef.current;
 };
+
+export const isSafari = () =>
+  typeof navigator !== 'undefined' && navigator.vendor.includes('Apple');
+
+export const isMac = () => typeof navigator !== 'undefined' && navigator.platform === 'MacIntel';


### PR DESCRIPTION
修复ant design 中 关于Progress组件在Safari浏览器中，浏览器缩放导致Circle不能正常显示的bug。
相关issue: https://github.com/ant-design/ant-design/issues/38026