### PR TITLE
fix(line): hide when length subpath is zero

### DIFF
--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -67,6 +67,7 @@ const Line: React.FC<ProgressProps> = ({
         };
         const color = strokeColorList[index] || strokeColorList[strokeColorList.length - 1];
         stackPtg += ptg;
+        console.log({ptg});
         return (
           <path
             key={index}
@@ -76,6 +77,7 @@ const Line: React.FC<ProgressProps> = ({
             stroke={color as string}
             strokeWidth={strokeWidth}
             fillOpacity="0"
+            opacity={ptg === 0 ? 0 : 1}
             ref={(elem) => {
               // https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
               // React will call the ref callback with the DOM element when the component mounts,

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -67,7 +67,6 @@ const Line: React.FC<ProgressProps> = ({
         };
         const color = strokeColorList[index] || strokeColorList[strokeColorList.length - 1];
         stackPtg += ptg;
-        console.log({ptg});
         return (
           <path
             key={index}


### PR DESCRIPTION
This fix #133

As mentioned in [MDN: stroke-linecap](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap#round) it is the expected behavior of svg stroke-linecap for both round and square.

`The round value indicates that at the end of each subpath the stroke will be extended by a half circle with a diameter equal to the stroke width. **On a zero length subpath, the stroke consists of a full circle centered at the subpath's point.**`

`The square value indicates that at the end of each subpath the stroke will be extended by a rectangle with a width equal to half the width of the stroke and a height equal to the width of the stroke. **On a zero length subpath, the stroke consists of a square with its width equal to the stroke width, centered at the subpath's point.**`