### PR TITLE
feat: Use gapPlacement instead gapPosition

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ export default () => (
       <td>the gap degree of half circle, 0 - 360</td>
     </tr>
     <tr>
-      <td>gapPosition</td>
+      <td>gapPlacement</td>
       <td>String</td>
       <td>top</td>
-      <td>the gap position: can be `top`, `bottom`, `left`, or `right`. </td>
+      <td>the gap placement: can be `top`, `bottom`, `left`, or `right`. </td>
     </tr>
     <tr>
       <td>loading</td>

--- a/docs/examples/gap.tsx
+++ b/docs/examples/gap.tsx
@@ -67,7 +67,7 @@ class Example extends React.Component<ProgressProps, any> {
           <Circle
             percent={percent}
             gapDegree={70}
-            gapPosition="top"
+            gapPlacement="top"
             strokeWidth={6}
             strokeLinecap="square"
             strokeColor={color}
@@ -77,7 +77,7 @@ class Example extends React.Component<ProgressProps, any> {
           <Circle
             percent={multiPercentage}
             gapDegree={70}
-            gapPosition="bottom"
+            gapPlacement="bottom"
             strokeWidth={6}
             railWidth={6}
             strokeLinecap="round"
@@ -89,7 +89,7 @@ class Example extends React.Component<ProgressProps, any> {
           <Circle
             percent={percent}
             gapDegree={70}
-            gapPosition="left"
+            gapPlacement="left"
             strokeWidth={6}
             strokeLinecap="square"
             strokeColor={color}
@@ -99,7 +99,7 @@ class Example extends React.Component<ProgressProps, any> {
           <Circle
             percent={percent}
             gapDegree={70}
-            gapPosition="right"
+            gapPlacement="right"
             strokeWidth={6}
             strokeLinecap="square"
             strokeColor={color}

--- a/src/Circle/index.tsx
+++ b/src/Circle/index.tsx
@@ -22,6 +22,7 @@ const Circle: React.FC<ProgressProps> = (props) => {
     strokeWidth,
     railWidth,
     gapDegree = 0,
+    gapPlacement,
     gapPosition,
     railColor,
     strokeLinecap,
@@ -60,6 +61,7 @@ const Circle: React.FC<ProgressProps> = (props) => {
     loading,
   });
 
+  const mergedPlacement = gapPlacement ?? gapPosition ?? 'bottom';
   const circleStyle = getCircleStyle(
     perimeter,
     perimeterWithoutGap,
@@ -67,7 +69,7 @@ const Circle: React.FC<ProgressProps> = (props) => {
     100,
     rotateDeg,
     gapDegree,
-    gapPosition,
+    mergedPlacement,
     railColor,
     mergedStrokeLinecap,
     strokeWidth,
@@ -87,7 +89,7 @@ const Circle: React.FC<ProgressProps> = (props) => {
           ptg,
           rotateDeg,
           gapDegree,
-          gapPosition,
+          mergedPlacement,
           color,
           mergedStrokeLinecap,
           strokeWidth,
@@ -138,7 +140,7 @@ const Circle: React.FC<ProgressProps> = (props) => {
         stepPtg,
         rotateDeg,
         gapDegree,
-        gapPosition,
+        mergedPlacement,
         color,
         'butt',
         strokeWidth,

--- a/src/Circle/util.ts
+++ b/src/Circle/util.ts
@@ -11,14 +11,14 @@ export const getCircleStyle = (
   percent: number,
   rotateDeg: number,
   gapDegree: number,
-  gapPosition: ProgressProps['gapPosition'] | undefined,
+  gapPlacement: ProgressProps['gapPlacement'] | undefined,
   strokeColor: StrokeColorType,
   strokeLinecap: ProgressProps['strokeLinecap'],
   strokeWidth: number,
   stepSpace = 0,
 ): React.CSSProperties => {
   const offsetDeg = (offset / 100) * 360 * ((360 - gapDegree) / 360);
-  const positionDeg =
+  const placementDeg =
     gapDegree === 0
       ? 0
       : {
@@ -26,7 +26,7 @@ export const getCircleStyle = (
           top: 180,
           left: 90,
           right: -90,
-        }[gapPosition];
+        }[gapPlacement];
 
   let strokeDashoffset = ((100 - percent) / 100) * perimeterWithoutGap;
   // Fix percent accuracy when strokeLinecap is round
@@ -45,7 +45,7 @@ export const getCircleStyle = (
     stroke: typeof strokeColor === 'string' ? strokeColor : undefined,
     strokeDasharray: `${perimeterWithoutGap}px ${perimeter}`,
     strokeDashoffset: strokeDashoffset + stepSpace,
-    transform: `rotate(${rotateDeg + offsetDeg + positionDeg}deg)`,
+    transform: `rotate(${rotateDeg + offsetDeg + placementDeg}deg)`,
     transformOrigin: `${halfSize}px ${halfSize}px`,
     transition:
       'stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s',

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -27,8 +27,6 @@ const Line: React.FC<ProgressProps> = (props) => {
 
   const mergedId = useId(id);
 
-  // eslint-disable-next-line no-param-reassign
-  delete restProps.gapPosition;
   const percentList = Array.isArray(percent) ? percent : [percent];
   const strokeColorList = Array.isArray(strokeColor) ? strokeColor : [strokeColor];
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -9,7 +9,6 @@ export const defaultProps: Partial<ProgressProps> = {
   strokeWidth: 1,
   railColor: '#D9D9D9',
   railWidth: 1,
-  gapPosition: 'bottom',
   loading: false,
 };
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,6 +14,8 @@ export interface ProgressProps {
   prefixCls?: string;
   style?: React.CSSProperties;
   gapDegree?: number;
+  gapPlacement?: GapPositionType;
+  /** @deprecated Please use `gapPlacement` instead */
   gapPosition?: GapPositionType;
   transition?: string;
   onClick?: React.MouseEventHandler;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -224,6 +224,41 @@ describe('Progress', () => {
         'transform: rotate(120deg);',
       );
     });
+
+    const mockCircleProps = {
+      percent: 30,
+      strokeWidth: 6,
+      trailWidth: 6,
+      gapDegree: 0,
+    };
+
+    describe('gapPlacement and gapPosition behavior', () => {
+      it.each([
+        [{}, 'bottom'],
+        [{ gapPlacement: 'top' }, 'top'],
+        [{ gapPlacement: 'left' }, 'left'],
+        [{ gapPosition: 'bottom' }, 'bottom'],
+        [{ gapPosition: 'right' }, 'right'],
+        [{ gapPosition: 'top', gapPlacement: 'bottom' }, 'bottom'],
+      ])('should use %s when props are %j', async (props, expectedPlacement) => {
+        const getCircleStyleMock = jest.spyOn(require('../src/Circle/util'), 'getCircleStyle');
+        render(<Circle {...mockCircleProps} {...props} />);
+        expect(getCircleStyleMock).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          expectedPlacement,
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+        );
+
+        getCircleStyleMock.mockRestore();
+      });
+    });
   });
 
   it('should support percentage array changes', () => {


### PR DESCRIPTION
使用gapPlacement替换gapPosition
 https://github.com/ant-design/ant-design/issues/54266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 为进度组件新增了 gapPlacement 属性，用于指定圆环缺口的位置。

* **文档**
  * 更新了 README 文档，将 API 表中的 gapPosition 重命名为 gapPlacement，并同步了描述。
  * 示例代码同步使用 gapPlacement 属性。

* **样式**
  * 组件内部所有相关逻辑已统一使用 gapPlacement，gapPosition 标记为已废弃。

* **测试**
  * 增加了 gapPlacement 与 gapPosition 行为的测试用例，确保兼容性和优先级正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->