### PR TITLE
Avoid util deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "now-build": "npm run docs:build"
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.4",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.4",
     "@testing-library/react": "^13.0.0",
     "@types/jest": "^29.4.0",

--- a/src/Circle/index.tsx
+++ b/src/Circle/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
+import { useId } from '@rc-component/util';
 import { defaultProps, useTransitionDuration } from '../common';
 import type { ProgressProps } from '../interface';
-import { useId } from '@rc-component/util';
 import PtgCircle from './PtgCircle';
 import { VIEW_BOX_SIZE, getCircleStyle } from './util';
 import getIndeterminateCircle from '../utils/getIndeterminateCircle';

--- a/src/Circle/index.tsx
+++ b/src/Circle/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { clsx } from 'clsx';
 import { defaultProps, useTransitionDuration } from '../common';
 import type { ProgressProps } from '../interface';
-import useId from '@rc-component/util/lib/hooks/useId';
+import { useId } from '@rc-component/util';
 import PtgCircle from './PtgCircle';
 import { VIEW_BOX_SIZE, getCircleStyle } from './util';
 import getIndeterminateCircle from '../utils/getIndeterminateCircle';

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { useTransitionDuration, defaultProps } from './common';
 import type { ProgressProps } from './interface';
 import getIndeterminateLine from './utils/getIndeterminateLine';
-import useId from '@rc-component/util/lib/hooks/useId';
+import { useId } from '@rc-component/util';
 
 const Line: React.FC<ProgressProps> = (props) => {
   const {

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
+import { useId } from '@rc-component/util';
 import { useTransitionDuration, defaultProps } from './common';
 import type { ProgressProps } from './interface';
 import getIndeterminateLine from './utils/getIndeterminateLine';
-import { useId } from '@rc-component/util';
 
 const Line: React.FC<ProgressProps> = (props) => {
   const {


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到当前 latest `^1.11.1`。
- 升级 `@rc-component/father-plugin` 到 `^2.2.0`，交由插件统一处理 rc 深路径 import 限制。
- 将源码中对 `@rc-component/util/lib/hooks/useId` 的引用改为从 `@rc-component/util` 根入口导入。

## 背景

配合 rc 包统一避免依赖其他 rc 包的 `es` / `lib` 构建产物内部路径，改为使用公开根入口 API。

## 验证

- `git diff --check`
- 此前批量调整中已跑通 `npm run compile`、`npm run lint`、`npm test`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 升级运行时与开发依赖以获得底层改进与稳定性（包括部分组件工具包与构建插件的版本提升）。
* **Refactor**
  * 优化了若干组件的内部导入/钩子引用方式，提升代码可维护性且不影响组件行为与对外接口。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/progress/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->